### PR TITLE
fix(assigning-users-pagination): change to return 10 users

### DIFF
--- a/src/services/findVerifiedUsers.js
+++ b/src/services/findVerifiedUsers.js
@@ -1,7 +1,7 @@
 import models from '../models';
 
 const isUserVerified = async (page = 1) => {
-  const pageSize = 2;
+  const pageSize = 10;
   const skip = parseInt((page - 1) * pageSize, 10);
   const verifiedUser = await models.User.findAndCountAll({
     limit: pageSize, offset: skip, where: { verified: true }, attributes: { exclude: ['password', 'refreshtoken'] }, required: false


### PR DESCRIPTION
# Description

This PR is for changing the number of returned users from 2 to 10 as suggested by @bdushimi , so that on the front-end the display of verified users will not be spacious and enlarged for the sake of fitting 2 users in a listing. This meets the design of the mockup found at https://www.figma.com/file/hM1DgjHISuEDVenacmEyo7/Barefoot-Nomad?node-id=2%3A704

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How should this be manually tested or reproduced?

open the route `/api/v1/assignUserstoManager/verified-users?page=1` with postman and the rows property should not have more than 10 elements (users).

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots (if applicable)